### PR TITLE
Fix ProductRepository PHPDoc

### DIFF
--- a/app/Repositories/ProductRepository.php
+++ b/app/Repositories/ProductRepository.php
@@ -52,7 +52,7 @@ class ProductRepository implements RepositoryInterface
      *
      * @param int $id
      * @param array $data
-     * @return array
+     * @return bool
      */
     public function update(int $id, array $data): bool
     {


### PR DESCRIPTION
## Summary
- correct the return type for `update` in `ProductRepository`

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe33783c8333a6d2012e0d6258a4